### PR TITLE
Use logarithmic scale on LADSPA inputs that request it

### DIFF
--- a/ctl_equal.c
+++ b/ctl_equal.c
@@ -115,10 +115,18 @@ static int equal_read_integer(snd_ctl_ext_t *ext, snd_ctl_ext_key_t key,
 	int i;
 
 	for(i = 0; i < equal->control_data->channels; i++) {
-		value[i] = ((equal->control_data->control[key].data[i] -
-			equal->control_info[key].min)/
-			(equal->control_info[key].max-
-			equal->control_info[key].min))*100;
+		if(equal->control_info[key].isLog) {
+			float logValue = equal->control_data->control[key].data[i];
+			float min = equal->control_info[key].min;
+			float max = equal->control_info[key].max;
+			float linearlyScaledValue = log(logValue/min) / log(max/min);
+			value[i] = roundf(linearlyScaledValue * 100);
+		} else {
+			value[i] = ((equal->control_data->control[key].data[i] -
+				equal->control_info[key].min)/
+				(equal->control_info[key].max-
+				equal->control_info[key].min))*100;
+		}
 	}
 
 	return equal->control_data->channels*sizeof(long);

--- a/ctl_equal.c
+++ b/ctl_equal.c
@@ -134,7 +134,7 @@ static int equal_write_integer(snd_ctl_ext_t *ext, snd_ctl_ext_key_t key,
 	for(i = 0; i < equal->control_data->channels; i++) {
 		setting = value[i];
 
-		if(!equal->control_info[key].isLog) {
+		if(equal->control_info[key].isLog) {
       		float min = equal->control_info[key].min;
       		float max = equal->control_info[key].max;
       		float logarithmicallyScaledValue = min * pow(max/min, (setting/100));


### PR DESCRIPTION
Hi raedwulf,

I'm not sure what the current state of this repo is, but you seem to be at least inofficially the maintainer of this plugin for now, so I'd like to suggest an improvement to it. I tried to use this with the parametric EQ from the CAPS collection; however, I had the problem that the frequency control was mapped linearly from 20Hz to 14kHz over 0-100%, which is not very useful, especially in the low end range. LADSPA plugins do have a way of suggesting to use a logarithmic scale for input controls, though. This PR tries to detect such inputs and then apply control values after scaling them logarithmically over the min/max range. For me, this allows way better control of i.e. the Eq4p freqency.

The code might be a bit rough since I'm not a full time C developer; let me know if you have improvements to suggest.

Best,
Benjamin.